### PR TITLE
removendo exemplos

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,7 +32,7 @@ export default function Home() {
         <h2 className="text-2xl font-semibold text-ink dark:text-[#E6EDF7] mb-6">
           O que você encontrará:
         </h2>
-        <div className="grid md:grid-cols-3 gap-6">
+        <div className="grid md:grid-cols-2 gap-6 mx-auto w-full">
           <a href="/tutoriais" className="group">
             <div className="bg-surface-alt dark:bg-surface-dark rounded-xl p-6 shadow-card group-hover:shadow-cardHover transition">
               <h3 className="text-brand dark:text-brand-soft font-bold mb-2">
@@ -44,19 +44,9 @@ export default function Home() {
               </p>
             </div>
           </a>
-          <a href="/exemplos" className="group">
-            <div className="bg-surface-alt dark:bg-surface-dark rounded-xl p-6 shadow-card group-hover:shadow-cardHover transition">
-              <h3 className="text-brand dark:text-brand-soft font-bold mb-2">
-                Exemplos
-              </h3>
-              <p className="text-ink-muted dark:text-ink-dark">
-                Trechos de código e demonstrações práticas para aprendizado
-                rápido.
-              </p>
-            </div>
-          </a>
+          
           <a href="/exercicios" className="group">
-            <div className="bg-surface-alt dark:bg-surface-dark rounded-xl p-6 shadow-card group-hover:shadow-cardHover transition">
+            <div className=" h-full bg-surface-alt dark:bg-surface-dark rounded-xl p-6 shadow-card group-hover:shadow-cardHover transition">
               <h3 className="text-brand dark:text-brand-soft font-bold mb-2">
                 Exercícios
               </h3>

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -7,7 +7,6 @@ type NavLink = { href: string; label: string };
 
 const links: NavLink[] = [
   { href: "/tutoriais", label: "Tutoriais" },
-  { href: "/exemplos", label: "Exemplos" },
   { href: "/exercicios", label: "Exercícios" },
   { href: "/contato", label: "Contato" },
 ];


### PR DESCRIPTION
This pull request updates the homepage layout and navigation links to remove references to the "Exemplos" section, streamlining the user experience to focus on tutorials and exercises.

Homepage layout changes:

* The grid on the homepage (`src/app/page.tsx`) was changed from three columns to two columns, and the "Exemplos" card was removed. The remaining cards are now centered with improved spacing. [[1]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL35-R35) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL47-R49)

Navigation updates:

* The "Exemplos" link was removed from the header navigation (`src/components/header/index.tsx`), so users will no longer see or access this section from the main navigation.